### PR TITLE
fix: [discord.voice_channel_creation] section typo in config.example …

### DIFF
--- a/config.example
+++ b/config.example
@@ -67,7 +67,7 @@ log_level = "DEBUG"
             "_Spectacle & streaming",
             "_Logistique",
         ]
-    [voice_channel_creation]
+    [discord.voice_channel_creation]
         trigger_channel_name = "Créer un salon vocal"
         new_channel_name = "🤝 Réunion"
         bitrate = 96000


### PR DESCRIPTION
…for the feature to work properly